### PR TITLE
Expose dateGenerator

### DIFF
--- a/src/plugins/jquery.flot.time.js
+++ b/src/plugins/jquery.flot.time.js
@@ -460,5 +460,6 @@ API.txt for details.
     // on the function, so we need to re-expose it here.
 
     $.plot.formatDate = formatDate;
-
+    $.plot.dateGenerator = dateGenerator;
+    
 })(jQuery);


### PR DESCRIPTION
`dateGenerator` is useful for plugins and applications working with timezone data and should be exposed similar to `formatDate`.